### PR TITLE
Pin packaging < 22.0

### DIFF
--- a/setup.py
+++ b/setup.py
@@ -28,7 +28,7 @@ except OSError:
 requirements = [
     'click >= 6.7',
     'jinja2',
-    'packaging',
+    'packaging < 22.0',
     'pyparsing >= 2.0.2',
     'setuptools',
     'sphinx',


### PR DESCRIPTION
In version 22.0, `packaging` dropped `LegacyVersion`, which we rely on.

See https://github.com/pypa/packaging/issues/321

This is a stop-gap measure to address #27 until a workaround can be implemented.