### PR TITLE
MNT: compatibility with newer packaging

### DIFF
--- a/setup.py
+++ b/setup.py
@@ -28,7 +28,7 @@ except OSError:
 requirements = [
     'click >= 6.7',
     'jinja2',
-    'packaging < 22.0',
+    'packaging',
     'pyparsing >= 2.0.2',
     'setuptools',
     'sphinx',

--- a/src/docs_versions_menu/groups.py
+++ b/src/docs_versions_menu/groups.py
@@ -1,6 +1,5 @@
 """Classification of folders into groups according to :pep:`440`."""
-from packaging.version import LegacyVersion
-from packaging.version import parse as parse_version
+from packaging.version import InvalidVersion, Version
 
 
 def get_groups(folders, default_branches=None):
@@ -48,10 +47,11 @@ def get_groups(folders, default_branches=None):
         'default-branch': set(),
     }
     for folder in folders:
-        version = parse_version(folder)
-        if folder in default_branches:
-            groups['default-branch'].add(folder)
-        if isinstance(version, LegacyVersion):
+        try:
+            version = Version(folder)
+        except InvalidVersion:
+            if folder in default_branches:
+                groups['default-branch'].add(folder)
             groups['branches'].add(folder)
         else:
             groups['releases'].add(folder)


### PR DESCRIPTION
I dug into this a bit because newer versions of `black` and `conda` require `packaging>=22.0`.

Following recommendations here: https://github.com/pypa/packaging/issues/631#issuecomment-1343479721
The simplest way to support all versions of packaging is to use the `Version` class directly instead of the `parse` function.

`parse` used to return `Version` or `LegacyVersion` depending on if it received a valid version string, but now it raises `InvalidVersion` instead if the version string is invalid. If we add a try/except around `parse` then you'll be compatible with `packaging>=22` but lose compatibility with `packaging<22`. Instead, switching to the `Version` class directly has the same exception raising behavior in all versions of `packaging`, including the latest.

This seemed like an appropriate fix here because this library only uses `LegacyVersion` as an indicator that something is a branch rather than a version, so its absence doesn't seem like much of a problem.

closes #27 