### PR TITLE
Remove jQuery dependency

### DIFF
--- a/HISTORY.rst
+++ b/HISTORY.rst
@@ -9,8 +9,8 @@ Unreleased
 * Updated pyparsing API to use non-deprecated function names
   (``DelimitedList``, ``one_of``, ``set_parse_action``, ``parse_string``,
   ``as_list``)
-* Added documentation note about the ``sphinxcontrib.jquery`` dependency
-  required when using Sphinx >= 6.0
+* Removed jQuery dependency from the versions-menu JavaScript (`#33`_, `#25`_);
+  the ``sphinxcontrib.jquery`` workaround is no longer needed
 * Dropped support for Python 3.9 (EOL)
 * Added support for Python 3.13
 * Dropped support for Sphinx < 7.2
@@ -149,7 +149,9 @@ folders in a project's ``gh-pages`` branch.
 .. _#13: https://github.com/goerz/docs_versions_menu/issues/13
 .. _#15: https://github.com/goerz/docs_versions_menu/issues/15
 .. _#18: https://github.com/goerz/docs_versions_menu/issues/18
+.. _#25: https://github.com/goerz/docs_versions_menu/issues/25
 .. _#27: https://github.com/goerz/docs_versions_menu/issues/27
 .. _#28: https://github.com/goerz/docs_versions_menu/issues/28
 .. _#32: https://github.com/goerz/docs_versions_menu/issues/32
+.. _#33: https://github.com/goerz/docs_versions_menu/issues/33
 .. _conda-feedstock: https://github.com/conda-forge/docs-versions-menu-feedstock#readme

--- a/README.rst
+++ b/README.rst
@@ -81,10 +81,6 @@ Feedstock <conda-feedstock-instructions_>`_.
 Usage
 -----
 
-.. warning::
-
-   This plugin currently relies on jQuery, which is `no longer automatically included in Sphinx >= 6.0`_. You may need to add ``sphinxcontrib.jquery`` to the extensions list in ``conf.py`` in order for the versions menu to appear.
-
 Showing a versions-menu in your documentation requires two steps:
 
 1.  Add ``'docs_versions_menu'`` to the list of extensions in your Sphinx ``conf.py``.

--- a/src/docs_versions_menu/_template/docs-versions-menu.js_t
+++ b/src/docs_versions_menu/_template/docs-versions-menu.js_t
@@ -1,7 +1,7 @@
 "use strict";
 
 function getGhPagesCurrentFolder() {
-  // Extract version folder under the assumpgion that the URL is of the form
+  // Extract version folder under the assumption that the URL is of the form
   // https://<username>.github.io/<project>/<version>/...
   if (window.location.hostname.includes("github.io")){
     return window.location.pathname.split('/')[2];
@@ -11,7 +11,7 @@ function getGhPagesCurrentFolder() {
 function getRootUrl() {
   // Return the "root" URL, i.e. everything before the current folder
   // (getGhPagesCurrentFolder). On gh-pages, this includes the project name.
-  var root_url = window.location.origin;
+  let root_url = window.location.origin;
   if (window.location.hostname.includes("github.io")){
     root_url = root_url + '/' + window.location.pathname.split('/')[1];
   }
@@ -21,11 +21,11 @@ function getRootUrl() {
 function getGithubProjectUrl(){
   // Return the project url on Github, under the assumption that the current
   // page is hosted on github-pages (https://<username>.github.io/<project>/)
-  var root_url = getRootUrl();
-  var match = root_url.match(/([\w\d-]+)\.github\.io\/([\w\d-]+)/)
+  const root_url = getRootUrl();
+  const match = root_url.match(/([\w\d-]+)\.github\.io\/([\w\d-]+)/)
   if (match !== null){
-    var username = match[1];
-    var projectname = match[2];
+    const username = match[1];
+    const projectname = match[2];
     return "https://github.com/" + username + "/" + projectname;
   } else {
     return null
@@ -35,13 +35,13 @@ function getGithubProjectUrl(){
 function _addVersionsMenu(version_data) {
   // The menu was reverse-engineered from the RTD websites, so it's very
   // specific to the sphinx_rtd_theme
-  var folders = version_data["versions"];
-  var root_url = getRootUrl();
-  var current_url = document.URL;
-  var current_folder = {{ "%r" % current_folder }};
+  const folders = version_data["versions"];
+  const root_url = getRootUrl();
+  const current_url = document.URL;
+  const current_folder = {{ "%r" % current_folder }};
   if (current_folder === undefined) return;
-  var current_version = version_data["labels"][current_folder];
-  var menu = document.createElement('div');
+  const current_version = version_data["labels"][current_folder];
+  const menu = document.createElement('div');
   {%- if badge_only %}
   menu.setAttribute('class', 'rst-versions rst-badge');
   {%- else %}
@@ -50,7 +50,7 @@ function _addVersionsMenu(version_data) {
   menu.setAttribute('data-toggle', 'rst-versions');
   menu.setAttribute('role', 'note');
   menu.setAttribute('aria-label', 'versions');
-  var inner_html =
+  let inner_html =
     "<span class='rst-current-version' data-toggle='rst-current-version'>" +
       "<span class='fa fa-book'> {% if not badge_only %}{{ menu_title }}{% endif%} </span>" +
       "<span>" + current_version + " </span>" +
@@ -60,44 +60,42 @@ function _addVersionsMenu(version_data) {
       "<div class='injected'>" +
         "<dl>" +
           "<dt>Versions</dt>";
-  var i;
-  for (i in folders) {
-    var folder = folders[i];
-    if (folder == current_folder){
-      var inner_html = inner_html + "<strong><dd><a href='"
+  for (const folder of folders) {
+    if (folder === current_folder){
+      inner_html += "<strong><dd><a href='"
                        + current_url
                        + "'>" + current_version + "</a></dd></strong>";
     } else {
-      var inner_html = inner_html + "<dd><a href='"
+      inner_html += "<dd><a href='"
                        + current_url.replace(current_folder, folder)
                        + "'>" + version_data["labels"][folder] + "</a></dd>";
     }
   }
-  var downloads = version_data["downloads"][current_folder];
+  const downloads = version_data["downloads"][current_folder];
   if (downloads.length > 0){
-    var inner_html = inner_html +
+    inner_html +=
           "<dt>Downloads</dt>";
-    for (i in downloads) {
-      var download_label = downloads[i][0];
-      var download_url = downloads[i][1];
+    for (const download of downloads) {
+      const download_label = download[0];
+      let download_url = download[1];
       if (!(/^(https?|ftp):/.test(download_url))){
           if (!download_url.startsWith('/')){
-              var download_url = '/' + download_url;
+              download_url = '/' + download_url;
           }
-          var download_url = root_url + download_url;
+          download_url = root_url + download_url;
       }
-      var inner_html = inner_html + "<dd><a href='" + download_url + "'>"
+      inner_html += "<dd><a href='" + download_url + "'>"
                      + download_label + "</a></dd>";
     }
   }
-  var github_project_url = {{ "%r" % github_project_url }};
+  const github_project_url = {{ "%r" % github_project_url }};
   if (github_project_url !== null && github_project_url.length > 0){
-    var inner_html = inner_html +
+    inner_html +=
           "<dt>On Github</dt>"
           + "<dd><a href='" + github_project_url + "'>Project Home</a></dd>"
           + "<dd><a href='" + github_project_url + "/issues'>Issues</a></dd>";
   }
-  var inner_html = inner_html +
+  inner_html +=
         "</dl>" +
         "<hr>" +
         "<small>Generated by <a href='https://goerz.github.io/docs_versions_menu'>Docs Versions Menu</a>" +
@@ -105,12 +103,12 @@ function _addVersionsMenu(version_data) {
       "</div>" +
     "</div>";
   menu.innerHTML = inner_html;
-  var parent = document.body;
+  const parent = document.body;
   parent.insertBefore(menu, parent.lastChild);
 
   // Add a warning banner for dev/outdated versions
-  var warning;
-  var msg;
+  let warning;
+  let msg;
   if (version_data["warnings"][current_folder].indexOf("outdated") >=0){
     warning = document.createElement('div');
     warning.setAttribute('class', 'admonition danger');
@@ -132,27 +130,33 @@ function _addVersionsMenu(version_data) {
     }
     warning.innerHTML = "<p class='first admonition-title'>Note</p> " +
       "<p class='last'> " + msg + "</p>";
-    var parent = document.querySelector('div.body')
+    const warn_parent = document.querySelector('div.body')
       || document.querySelector('div.document')
       || document.body;
-    parent.insertBefore(warning, parent.firstChild);
+    warn_parent.insertBefore(warning, warn_parent.firstChild);
   }
 
 
 }
 
 function addVersionsMenu() {
-  // We assume that we can load versions.json from
-  // https://<username>.github.io/<project>/versions.json
-  // That is, there's a <project> path between the hostname and versions.json
-  var json_file = {{ "%r" % json_file }};
-  $.getJSON(json_file, _addVersionsMenu);
+  const json_file = {{ "%r" % json_file }};
+  fetch(json_file)
+    .then(response => response.json())
+    .then(_addVersionsMenu)
+    .catch(err => console.error("docs-versions-menu: failed to load " + json_file, err));
 
   {%- if badge_only %}
 
-  $( "body" ).on('click', "div.rst-versions.rst-badge", function() {
-      $('.rst-other-versions').toggle();
-      $('.rst-versions .rst-current-version .fa-book').toggleClass('shift-up');
+  document.body.addEventListener('click', function(e) {
+    if (e.target.closest('div.rst-versions.rst-badge')) {
+      document.querySelectorAll('.rst-other-versions').forEach(
+        el => { el.style.display = el.style.display === 'none' ? '' : 'none'; }
+      );
+      document.querySelectorAll('.rst-versions .rst-current-version .fa-book').forEach(
+        el => el.classList.toggle('shift-up')
+      );
+    }
   });
 
   {%- endif %}

--- a/src/docs_versions_menu/_template/docs-versions-menu.js_t
+++ b/src/docs_versions_menu/_template/docs-versions-menu.js_t
@@ -91,7 +91,7 @@ function _addVersionsMenu(version_data) {
   const github_project_url = {{ "%r" % github_project_url }};
   if (github_project_url !== null && github_project_url.length > 0){
     inner_html +=
-          "<dt>On Github</dt>"
+          "<dt>On GitHub</dt>"
           + "<dd><a href='" + github_project_url + "'>Project Home</a></dd>"
           + "<dd><a href='" + github_project_url + "/issues'>Issues</a></dd>";
   }
@@ -142,7 +142,10 @@ function _addVersionsMenu(version_data) {
 function addVersionsMenu() {
   const json_file = {{ "%r" % json_file }};
   fetch(json_file)
-    .then(response => response.json())
+    .then(response => {
+      if (!response.ok) throw new Error(response.status + ' ' + response.statusText);
+      return response.json();
+    })
     .then(_addVersionsMenu)
     .catch(err => console.error("docs-versions-menu: failed to load " + json_file, err));
 
@@ -151,7 +154,7 @@ function addVersionsMenu() {
   document.body.addEventListener('click', function(e) {
     if (e.target.closest('div.rst-versions.rst-badge')) {
       document.querySelectorAll('.rst-other-versions').forEach(
-        el => { el.style.display = el.style.display === 'none' ? '' : 'none'; }
+        el => { el.style.display = window.getComputedStyle(el).display === 'none' ? '' : 'none'; }
       );
       document.querySelectorAll('.rst-versions .rst-current-version .fa-book').forEach(
         el => el.classList.toggle('shift-up')


### PR DESCRIPTION
Replace $.getJSON with fetch() and jQuery event/DOM helpers with vanilla JS equivalents. Also modernize var → let/const and for…in on arrays → for…of. Closes #33; relates to #25.