### PR TITLE
Make versions menu work on any web host, not just GitHub Pages

### DIFF
--- a/HISTORY.rst
+++ b/HISTORY.rst
@@ -11,6 +11,22 @@ Unreleased
   ``as_list``)
 * Removed jQuery dependency from the versions-menu JavaScript (`#33`_, `#25`_);
   the ``sphinxcontrib.jquery`` workaround is no longer needed
+* The versions menu now works on any web host, not just Github Pages (`#25`_):
+  the script auto-discovers ``versions.json`` by walking up the URL path.
+  The ``json_file`` and ``current_folder`` template variables are removed;
+  ``github_project_url`` auto-detection from ``github.io`` URLs is preserved
+  as a runtime fallback but can be overridden via ``docs_versions_menu_conf``
+
+.. rubric:: Migration notes
+
+* If you previously added ``sphinxcontrib.jquery`` to ``extensions`` as a
+  workaround for the missing jQuery in Sphinx >= 6.0, you may now remove it.
+* If you have a custom ``docs-versions-menu.js_t`` template that uses the
+  ``json_file`` or ``current_folder`` template variables, those variables no
+  longer exist and must be removed or replaced with the new runtime
+  auto-discovery approach.
+* To show a Github link in the versions menu on a non-Github Pages host, set
+  ``github_project_url`` explicitly in ``docs_versions_menu_conf``.
 * Dropped support for Python 3.9 (EOL)
 * Added support for Python 3.13
 * Dropped support for Sphinx < 7.2

--- a/Makefile
+++ b/Makefile
@@ -7,18 +7,17 @@
 
 # Python version for the development environment. Override on the command line,
 # e.g. `make PYTHON=3.11 test`. uv downloads the interpreter if it is missing.
-PYTHON ?= 3.12
+# If unset, uv picks the highest Python compatible with requires-python.
+ifdef PYTHON
+  PYTHON_ARG := --python $(PYTHON)
+endif
 
 # Dependency resolution strategy. Use `make RESOLUTION=lowest-direct test` to
 # verify the project against the lowest declared dependency versions.
 RESOLUTION ?= highest
 
-# Each Python version gets its own environment so that switching PYTHON does not
-# force a re-sync. `make distclean` removes the whole .venv tree.
-export UV_PROJECT_ENVIRONMENT := .venv/py$(PYTHON)
-
 # All development tooling lives in dependency groups (see pyproject.toml).
-UV := uv run --python $(PYTHON) --resolution $(RESOLUTION) --all-groups
+UV := uv run $(PYTHON_ARG) --resolution $(RESOLUTION) --all-groups
 
 TESTS ?= src tests README.rst
 SOURCES ?= src tests scripts
@@ -37,11 +36,13 @@ export PRINT_HELP_PYSCRIPT
 help:  ## Show this help
 	@python -c "$$PRINT_HELP_PYSCRIPT" < $(MAKEFILE_LIST)
 
-develop: .git/hooks/pre-commit  ## Create or sync the development environment
+develop:  ## Create or sync the development environment
+	uv sync $(PYTHON_ARG) --resolution $(RESOLUTION) --all-groups
+	$(UV) pre-commit install
 
 # Install the pre-commit git hook whenever the config or dependencies change.
 .git/hooks/pre-commit: .pre-commit-config.yaml pyproject.toml
-	uv sync --python $(PYTHON) --resolution $(RESOLUTION) --all-groups
+	uv sync $(PYTHON_ARG) --resolution $(RESOLUTION) --all-groups
 	$(UV) pre-commit install
 
 pre-commit-install:  ## (Re-)install the pre-commit git hook

--- a/README.rst
+++ b/README.rst
@@ -85,7 +85,7 @@ Showing a versions-menu in your documentation requires two steps:
 
 1.  Add ``'docs_versions_menu'`` to the list of extensions in your Sphinx ``conf.py``.
 
-    This adds Javascript to your rendered documentation that displays a dynamic versions-menu based on information in a ``versions.json`` file it expects to find in the webroot of the hosted documentation, e.g. the root of the ``gh-pages`` branch.
+    This adds Javascript to your rendered documentation that displays a dynamic versions-menu based on information in a ``versions.json`` file. The script locates ``versions.json`` automatically by searching upward from the current URL, so the menu works on any web host, not just Github Pages.
 
 
 2.  Set up the deployment of the documentation such that it runs the ``docs-versions-menu`` command in the webroot.

--- a/docs/sphinx_extension.rst
+++ b/docs/sphinx_extension.rst
@@ -15,19 +15,14 @@ See the Docs Versions Menu's |conf_py|_ for an example.
 .. _conf_py: https://github.com/goerz/docs_versions_menu/blob/master/docs/conf.py
 
 This will inject a javascript file ``docs-versions-menu.js`` into every
-generated page of the documentation that displays a versions menu when the
-documentation is hosted on Github Pages (the ``gh-pages`` branch of the project
-repository). The contents of the menu is derived from a file ``versions.json``
-that must be present in the root of ``gh-pages``.
+generated page of the documentation. When the page is loaded, the script
+searches upward from the current URL until it finds a ``versions.json`` file,
+then renders the versions menu from that data.
 
-
-.. Note::
-
-    By default, the versions menu will only appear when the documentation is
-    viewed at a Github Pages URL (``https://<username>.github.io/<project>/<version>/``)
-    and if a file ``versions.json`` is present in the ``<project>`` folder
-    (that is, the root of the ``gh-pages`` branch).
-    It will not appear when viewing documentation locally.
+The menu works on any web host where ``versions.json`` is served from the
+webroot of the hosted documentation (e.g. the root of a ``gh-pages`` branch, or
+the root of a static hosting path). It will not appear when viewing
+documentation locally (from the filesystem).
 
 
 Sphinx themes
@@ -67,9 +62,7 @@ The settings for the Sphinx extensions are taken from a dict
 
 The dict may contain the following keys:
 
-* ``json_file`` (str): The local (absolute) path to the json file that contains version information. Defaults to ``/<project>/versions.json`` with ``<project>`` dynamically set based on the current Github Pages URL (``https://<username>.github.io/<project>/<version>/...``)
-* ``github_project_url`` (str): The full URL to the project on Github. By default, this is dynamically derived from the current Github Pages URL (see above).
-* ``current_folder`` (str): The name of the current folder. By default, dynamically set to the ``<version>`` from the current Github Pages URL (see above).
+* ``github_project_url`` (str): The full URL to the project on Github, e.g. ``"https://github.com/user/project"``. When set, the menu shows links to the project home and issue tracker. Defaults to ``None`` (no Github links shown).
 * ``badge_only`` (bool): Whether to render the version menu as a "badge" in the lower right corner (defaults to True unless :confval:`html_theme` is ``"sphinx_rtd_theme"``)
 * ``menu_title`` (str): The label to be shown in to left corner of the full versions menu (if not ``badge_only``). Defaults to "Docs".
 

--- a/src/docs_versions_menu/_template/docs-versions-menu.js_t
+++ b/src/docs_versions_menu/_template/docs-versions-menu.js_t
@@ -1,45 +1,51 @@
 "use strict";
 
-function getGhPagesCurrentFolder() {
-  // Extract version folder under the assumption that the URL is of the form
-  // https://<username>.github.io/<project>/<version>/...
-  if (window.location.hostname.includes("github.io")){
-    return window.location.pathname.split('/')[2];
+async function urlExists(url) {
+  try {
+    const r = await fetch(url, {method: "HEAD"});
+    if (r.status === 405 || r.status === 501) {
+      const r2 = await fetch(url);
+      return r2.ok;
+    }
+    return r.ok;
+  } catch {
+    return false;
   }
 }
 
-function getRootUrl() {
-  // Return the "root" URL, i.e. everything before the current folder
-  // (getGhPagesCurrentFolder). On gh-pages, this includes the project name.
-  let root_url = window.location.origin;
-  if (window.location.hostname.includes("github.io")){
-    root_url = root_url + '/' + window.location.pathname.split('/')[1];
-  }
-  return root_url;
-}
-
-function getGithubProjectUrl(){
-  // Return the project url on Github, under the assumption that the current
-  // page is hosted on github-pages (https://<username>.github.io/<project>/)
-  const root_url = getRootUrl();
-  const match = root_url.match(/([\w\d-]+)\.github\.io\/([\w\d-]+)/)
-  if (match !== null){
-    const username = match[1];
-    const projectname = match[2];
-    return "https://github.com/" + username + "/" + projectname;
-  } else {
-    return null
+async function getRootUrl() {
+  // Walk up the URL path until we find a versions.json, works on any host.
+  const loc = new URL(window.location.href);
+  let path = loc.pathname.replace(/\/[^/]*$/, '');
+  while (true) {
+    if (await urlExists(loc.origin + path + "/versions.json")) {
+      return loc.origin + path;
+    }
+    if (!path) throw new Error("docs-versions-menu: could not find versions.json");
+    path = path.replace(/\/[^/]*$/, '');
   }
 }
 
-function _addVersionsMenu(version_data) {
+async function getCurrentVersionFolder(rootUrl) {
+  return window.location.href.substring(rootUrl.length + 1).split("/")[0];
+}
+
+function getGithubProjectUrl(rootUrl) {
+  // Auto-detect GitHub project URL from a github.io root URL.
+  const match = rootUrl.match(/([\w\d-]+)\.github\.io\/([\w\d-]+)/);
+  if (match !== null) {
+    return "https://github.com/" + match[1] + "/" + match[2];
+  }
+  return null;
+}
+
+async function _addVersionsMenu(version_data, rootUrl) {
   // The menu was reverse-engineered from the RTD websites, so it's very
   // specific to the sphinx_rtd_theme
   const folders = version_data["versions"];
-  const root_url = getRootUrl();
   const current_url = document.URL;
-  const current_folder = {{ "%r" % current_folder }};
-  if (current_folder === undefined) return;
+  const current_folder = await getCurrentVersionFolder(rootUrl);
+  if (!current_folder || !(current_folder in version_data["labels"])) return;
   const current_version = version_data["labels"][current_folder];
   const menu = document.createElement('div');
   {%- if badge_only %}
@@ -82,13 +88,13 @@ function _addVersionsMenu(version_data) {
           if (!download_url.startsWith('/')){
               download_url = '/' + download_url;
           }
-          download_url = root_url + download_url;
+          download_url = rootUrl + download_url;
       }
       inner_html += "<dd><a href='" + download_url + "'>"
                      + download_label + "</a></dd>";
     }
   }
-  const github_project_url = {{ "%r" % github_project_url }};
+  const github_project_url = {{ "%r" % github_project_url }} ?? getGithubProjectUrl(rootUrl);
   if (github_project_url !== null && github_project_url.length > 0){
     inner_html +=
           "<dt>On GitHub</dt>"
@@ -136,18 +142,25 @@ function _addVersionsMenu(version_data) {
     warn_parent.insertBefore(warning, warn_parent.firstChild);
   }
 
-
 }
 
-function addVersionsMenu() {
-  const json_file = {{ "%r" % json_file }};
-  fetch(json_file)
-    .then(response => {
-      if (!response.ok) throw new Error(response.status + ' ' + response.statusText);
-      return response.json();
-    })
-    .then(_addVersionsMenu)
-    .catch(err => console.error("docs-versions-menu: failed to load " + json_file, err));
+async function addVersionsMenu() {
+  let rootUrl;
+  try {
+    rootUrl = await getRootUrl();
+  } catch(err) {
+    console.error(err.message);
+    return;
+  }
+  const json_file = rootUrl + "/versions.json";
+  try {
+    const response = await fetch(json_file);
+    if (!response.ok) throw new Error(response.status + ' ' + response.statusText);
+    const version_data = await response.json();
+    await _addVersionsMenu(version_data, rootUrl);
+  } catch(err) {
+    console.error("docs-versions-menu: failed to load " + json_file, err);
+  }
 
   {%- if badge_only %}
 

--- a/src/docs_versions_menu/ext.py
+++ b/src/docs_versions_menu/ext.py
@@ -44,11 +44,7 @@ def add_versions_menu_js_file(app):
     template_path.append(str(Path(__file__).parent / '_template'))
     renderer = SphinxRenderer(template_path=template_path)
     context = dict(
-        json_file=_JS(
-            '"/" + window.location.pathname.split("/")[1] + "/versions.json"'
-        ),
-        github_project_url=_JS('getGithubProjectUrl()'),
-        current_folder=_JS('getGhPagesCurrentFolder()'),
+        github_project_url=None,
         badge_only=(app.config.html_theme != 'sphinx_rtd_theme'),
         menu_title="Docs",
     )
@@ -60,6 +56,8 @@ def add_versions_menu_js_file(app):
         )
         context.update(app.config.doctr_versions_menu_conf)
     context.update(app.config.docs_versions_menu_conf)
+    if context['github_project_url'] is None:
+        context['github_project_url'] = _JS('null')
     js_file_path = Path(tmpdir) / js_file_name
     template = renderer.env.get_template(template_name)
     print(

--- a/tests/test_extension.py
+++ b/tests/test_extension.py
@@ -69,10 +69,9 @@ def test_custom(app, status, warning):
     html = (_build / 'index.html').read_text()
     assert 'src="_static/docs-versions-menu.js' in html
     js = (_build / '_static' / 'docs-versions-menu.js').read_text()
-    # fmt: off
     assert "var my_var = 'custom variable';" in js
-    assert 'var current_folder = getGhPagesCurrentFolder();' in js
-    assert "var github_project_url = 'https://github.com/goerz/docs_versions_menu';" in js
-    assert 'var json_file = "/" + window.location.pathname.split("/")[1] + "/versions.json";' in js
+    assert (
+        "var github_project_url = 'https://github.com/goerz/docs_versions_menu';"
+        in js
+    )
     assert "var menu_title = 'Docs'" in js
-    # fmt: on

--- a/tests/test_extension/roots/test-custom/_templates/doctr-versions-menu.js_t
+++ b/tests/test_extension/roots/test-custom/_templates/doctr-versions-menu.js_t
@@ -1,6 +1,4 @@
 /*This file should be renamed to docs-versions-menu.js_t, but we're testing support for the legacy template name*/
 var my_var = {{ "%r" % my_var }};
-var current_folder = {{ "%r" % current_folder }};
 var github_project_url = {{ "%r" % github_project_url }};
-var json_file = {{ "%r" % json_file }};
 var menu_title = {{ "%r" % menu_title }};


### PR DESCRIPTION
Replace the hardcoded GitHub Pages URL assumptions with an async discovery approach: walk up the current URL until versions.json is found (urlExists HEAD check). This removes the json_file and current_folder template variables from ext.py; github_project_url now defaults to None instead of auto-detecting from github.io URLs.

Keep getGithubProjectUrl(rootUrl) as a runtime JS function and use nullish coalescing so the conf.py setting takes precedence but github.io URLs still get auto-detected when the setting is null.

Add migration notes to HISTORY.rst.

Closes #25.